### PR TITLE
個別記事取得apiを作成

### DIFF
--- a/src/app/api/article/[articleId]/route.ts
+++ b/src/app/api/article/[articleId]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getOgpInfo } from "@/lib/get-ogp-info";
+import prisma from "@/lib/prisma/client";
+
+export const GET = async (req: NextRequest, { params }: { params: { articleId: string } }) => {
+  const { articleId } = params;
+
+  const article = await prisma.article.findUnique({
+    include: { nodes: true },
+    where: { id: Number(articleId) },
+  });
+
+  if (!article) return NextResponse.json({}, { status: 404 });
+
+  const updatedNodes = await Promise.all(
+    article.nodes.map(async (node) => {
+      const ogp = await getOgpInfo(node.nodeUrl);
+      return {
+        ...node,
+        ogp, // OGPの画像URLを追加
+      };
+    }),
+  );
+
+  const updatedArticle = {
+    ...article,
+    nodes: updatedNodes,
+  };
+
+  return NextResponse.json(updatedArticle, { status: 200 });
+};


### PR DESCRIPTION
## 実装内容

## 実装経緯

## 動作確認方法
`http://localhost:3000/api/article/1`を叩く
`/2`だと空のオブジェクトが帰ってくる

## 懸念点
