### PR TITLE
galleryページAPIからデータ取得

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    images: {
+        remotePatterns: [
+            {
+                hostname: '**', // 全てのホスト名を許可
+                protocol: 'https',
+            },
+            {
+                hostname: '**', // 全てのホスト名を許可
+                protocol: 'http',
+            },
+        ],
+    },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
         "jsdom": "^24.1.1",
         "lucide-react": "^0.435.0",
         "next": "14.2.6",
@@ -2873,6 +2874,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
     "jsdom": "^24.1.1",
     "lucide-react": "^0.435.0",
     "next": "14.2.6",

--- a/src/app/components/gallery/Article.tsx
+++ b/src/app/components/gallery/Article.tsx
@@ -1,19 +1,8 @@
 import PostInfo from "@/app/components/gallery/ArticleInfo";
 import ArticleThumbnail from "@/app/components/gallery/ArticleThumbnail";
+import { GalleryArticle } from "@/types/gallery-articles";
 
-export type ArticleType = {
-  id: number;
-  title: string;
-  date: string;
-  thumbnail: {
-    articleImg: string;
-    articleTitle: string;
-  }[];
-  userImg: string;
-  username: string;
-};
-
-export default function Article({ article }: { article: ArticleType }) {
+export default function Article({ article }: { article: GalleryArticle }) {
   return (
     <article className="rounded-xl bg-white px-10 pb-8 pt-4 drop-shadow-lg">
       {/* 投稿情報 */}

--- a/src/app/components/gallery/ArticleInfo.tsx
+++ b/src/app/components/gallery/ArticleInfo.tsx
@@ -1,18 +1,20 @@
-import { ArticleType } from "@/app/components/gallery/Article";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { format } from "date-fns";
 
-export default function ArticleInfo({ article }: { article: ArticleType }) {
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
+import { GalleryArticle } from "@/types/gallery-articles";
+
+export default function ArticleInfo({ article }: { article: GalleryArticle }) {
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-3">
         <Avatar className="size-9 border">
-          <AvatarImage src={article.userImg} alt="ユーザー画像" className="size-9" />
-          <AvatarFallback>{article.username.charAt(0)}</AvatarFallback>
+          <AvatarImage src="" alt="ユーザー画像" className="size-9" />
+          {/* <AvatarFallback>{article.username.charAt(0)}</AvatarFallback> */}
         </Avatar>
-        <p className="text-[15px]">{article.username}</p>
+        <p className="text-[15px]">テストユーザ</p>
       </div>
       <div>
-        <time className="text-[15px]">{article.date}</time>
+        <time className="text-[15px]">{format(article.createdAt, "yyyy/MM/dd")}</time>
       </div>
     </div>
   );

--- a/src/app/components/gallery/ArticleThumbnail.tsx
+++ b/src/app/components/gallery/ArticleThumbnail.tsx
@@ -1,15 +1,15 @@
 import Image from "next/image";
 
-import { ArticleType } from "@/app/components/gallery/Article";
+import { GalleryArticle } from "@/types/gallery-articles";
 
-export default function ArticleThumbnail({ article }: { article: ArticleType }) {
+export default function ArticleThumbnail({ article }: { article: GalleryArticle }) {
   return (
     <div className="relative">
       <div className="relative space-y-8">
-        {article.thumbnail.map((thumbnail) => (
-          <div key={thumbnail.articleTitle} className="relative">
+        {article.nodes.map((node) => (
+          <div key={node.id} className="relative">
             <div className="rounded bg-[#FFDD81] p-2">
-              <Image className="w-full" src={thumbnail.articleImg} width={153} height={78} alt="記事サムネイル" />
+              <Image className="w-full" src={node.ogp["og:image"]} width={153} height={78} alt={node.ogp["og:title"]} />
             </div>
             <div className="absolute left-1/2 top-full h-8 w-1.5 -translate-x-1/2 bg-gray-300"></div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,105 +1,16 @@
-import Article, { ArticleType } from "@/app/components/gallery/Article";
+import Article from "@/app/components/gallery/Article";
+import { GalleryArticle } from "@/types/gallery-articles";
 
-export default function Home() {
-  const articles: ArticleType[] = [
-    {
-      id: 1,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 2,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 3,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 4,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 5,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 6,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-    {
-      id: 7,
-      title: "Next.jsで簡単なWebアプリが作れるようになる",
-      date: "2024/08/24",
-      thumbnail: [
-        {
-          articleImg: "/gallery-page/article-thumbnail-sample.png",
-          articleTitle: "Parralel RoutesとIntercepting Routesを使用したモーダル実装 モーダル実装 モーダル実装",
-        },
-      ],
-      userImg: "/gallery-page/user-img-sample.png",
-      username: "Somahc",
-    },
-  ];
+export default async function Home() {
+  const res = await fetch("http:/localhost:3000/api/articles");
+
+  const articleData: GalleryArticle[] = await res.json();
 
   return (
     <div className="bg-yellow-300">
       <div className="container px-[10px] py-[20px]">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {articles.map((article) => (
+          {articleData.map((article) => (
             <Article key={article.id} article={article} />
           ))}
         </div>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -12,7 +12,7 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ align = "center", className, sideOffset = 4, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
@@ -28,4 +28,4 @@ const PopoverContent = React.forwardRef<
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverContent,PopoverTrigger }

--- a/src/types/gallery-articles.d.ts
+++ b/src/types/gallery-articles.d.ts
@@ -1,0 +1,26 @@
+export type GalleryArticle = {
+    id: number;
+    title: string;
+    authorId: string;
+    createdAt: string;
+    nodes: Node[];
+    updatedAt: string;
+};
+
+export type Node = {
+    id: number;
+    articleId: number;
+    comment: string;
+    createdAt: string;
+    nodeTitle: string;
+    nodeUrl: string;
+    ogp: {
+        "og:image": string;
+        "og:site_name": string;
+        "og:title": string;
+        "og:type": string;  
+        "og:url": string;
+    };
+    order: number;
+    updatedAt: string;
+};


### PR DESCRIPTION
## 実装内容
galleryページで、APIからデータを取得するように変更を加えました。

## 実装経緯
動的にDBから表示記事を取得する必要があるため。

## 動作確認方法
`npm run dev`→トップページを見て記事が表示されていれば大丈夫です。

## 懸念点
APIに実装されていないusernameなどの一部必要な情報はハードコードしてあります。