### PR TITLE
apiからのユーザ情報取得

### DIFF
--- a/src/app/api/article/[articleId]/route.ts
+++ b/src/app/api/article/[articleId]/route.ts
@@ -7,7 +7,7 @@ export const GET = async (req: NextRequest, { params }: { params: { articleId: s
   const { articleId } = params;
 
   const article = await prisma.article.findUnique({
-    include: { nodes: true },
+    include: { author: true, nodes: true },
     where: { id: Number(articleId) },
   });
 

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -6,6 +6,7 @@ import prisma from "@/lib/prisma/client";
 export const GET = async () => {
   const articles = await prisma.article.findMany({
     include: {
+      author: true,
       nodes: true,
     },
   });


### PR DESCRIPTION
## 実装内容
記事前取得と詳細画面で使用するAPIから得られる情報にユーザ情報を含めました。

## 実装経緯
記事情報を表示する際にユーザ情報も必要なため。

## 動作確認方法
`/api/articles`と`/api/article/1`からそれぞれユーザ情報が取得できているのを確認してください。

## 懸念点
