### PR TITLE
galleryページの動的データ取得

### DIFF
--- a/src/app/components/gallery/ArticleInfo.tsx
+++ b/src/app/components/gallery/ArticleInfo.tsx
@@ -1,6 +1,6 @@
 import { format } from "date-fns";
 
-import { Avatar, AvatarImage } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { GalleryArticle } from "@/types/gallery-articles";
 
 export default function ArticleInfo({ article }: { article: GalleryArticle }) {
@@ -8,10 +8,10 @@ export default function ArticleInfo({ article }: { article: GalleryArticle }) {
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-3">
         <Avatar className="size-9 border">
-          <AvatarImage src="" alt="ユーザー画像" className="size-9" />
-          {/* <AvatarFallback>{article.username.charAt(0)}</AvatarFallback> */}
+          <AvatarImage src={article.author.image} alt="ユーザー画像" className="size-9" />
+          <AvatarFallback>{article.author.name.charAt(0)}</AvatarFallback>
         </Avatar>
-        <p className="text-[15px]">テストユーザ</p>
+        <p className="text-[15px]">{article.author.name}</p>
       </div>
       <div>
         <time className="text-[15px]">{format(article.createdAt, "yyyy/MM/dd")}</time>

--- a/src/app/components/gallery/ArticleThumbnail.tsx
+++ b/src/app/components/gallery/ArticleThumbnail.tsx
@@ -6,14 +6,18 @@ export default function ArticleThumbnail({ article }: { article: GalleryArticle 
   return (
     <div className="relative">
       <div className="relative space-y-8">
-        {article.nodes.map((node) => (
-          <div key={node.id} className="relative">
-            <div className="rounded bg-[#FFDD81] p-2">
-              <Image className="w-full" src={node.ogp["og:image"]} width={153} height={78} alt={node.ogp["og:title"]} />
-            </div>
-            <div className="absolute left-1/2 top-full h-8 w-1.5 -translate-x-1/2 bg-gray-300"></div>
+        <div key={article.nodes[0].id} className="relative">
+          <div className="rounded bg-[#FFDD81] p-2">
+            <Image
+              className="w-full"
+              src={article.nodes[0].ogp["og:image"]}
+              width={153}
+              height={78}
+              alt={article.nodes[0].ogp["og:title"]}
+            />
           </div>
-        ))}
+          <div className="absolute left-1/2 top-full h-8 w-1.5 -translate-x-1/2 bg-gray-300"></div>
+        </div>
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
+import Link from "next/link";
+
 import Article from "@/app/components/gallery/Article";
 import { GalleryArticle } from "@/types/gallery-articles";
 
 export default async function Home() {
-  const res = await fetch("http:/localhost:3000/api/articles");
+  const res = await fetch("http:/localhost:3000/api/articles", { cache: "no-store" });
 
   const articleData: GalleryArticle[] = await res.json();
 
@@ -10,7 +12,11 @@ export default async function Home() {
     <div className="bg-yellow-300">
       <div className="container px-[10px] py-[20px]">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          <Article key={articleData[0].id} article={articleData[0]} />
+          {articleData.map((article) => (
+            <Link href={`/article/${article.id}`} key={article.id}>
+              <Article article={article} />
+            </Link>
+          ))}
         </div>
       </div>
     </div>

--- a/src/lib/get-ogp-info.ts
+++ b/src/lib/get-ogp-info.ts
@@ -22,7 +22,5 @@ export const getOgpInfo = async (url: string) => {
             })
     );
 
-    console.log(ogp);
-
     return ogp;
 }

--- a/src/types/gallery-articles.d.ts
+++ b/src/types/gallery-articles.d.ts
@@ -1,6 +1,13 @@
 export type GalleryArticle = {
     id: number;
     title: string;
+    author: {
+        id: string;
+        name: string;
+        email: string;
+        emailVerified: string;
+        image: string;
+    };
     authorId: string;
     createdAt: string;
     nodes: Node[];


### PR DESCRIPTION
## 実装内容
galleryページの動的データ取得部分の修正を行いました。

## 実装経緯
ハードコード部の解消、nodesが1つの投稿に複数表示されていた問題の修正のため

## 動作確認方法
galleryページにアクセスして、1つの投稿につき1つのnodeしか表示されていないこと・ユーザ名などのデータが動的に取得できていることを確認できればOKです。

## 懸念点
細かい箇所は後々リファクタリングの必要がありそうです。
