### PR TITLE
fix: nextauthoptionsを外部ファイルに切り分けた

### DIFF
--- a/src/app/(page)/new/page.tsx
+++ b/src/app/(page)/new/page.tsx
@@ -1,8 +1,8 @@
 import { getServerSession } from "next-auth/next";
 
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import Blockpage from "@/app/components/new/blockpage";
 import CreateArticleHome from "@/app/components/new/createArticleHome";
+import { authOptions } from "@/lib/auth";
 
 export default async function Page() {
   const session = await getServerSession(authOptions);

--- a/src/app/api/article/new/route.ts
+++ b/src/app/api/article/new/route.ts
@@ -2,9 +2,8 @@ import { Node } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth/next";
 
+import { authOptions } from "@/lib/auth";
 import prisma from "@/lib/prisma/client";
-
-import { authOptions } from "../../auth/[...nextauth]/route";
 
 export const POST = async (req: NextRequest) => {
   const { title, nodes } = await req.json();

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,28 +1,6 @@
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { Session, User } from "next-auth";
 import NextAuth from "next-auth/next";
-import GithubProvider from "next-auth/providers/github";
 
-import prisma from "@/lib/prisma/client";
-
-export const authOptions = {
-  adapter: PrismaAdapter(prisma),
-  callbacks: {
-    async session({ session, user }: { session: Session; user: User }) {
-      if (session?.user) {
-        session.user.id = user.id;
-      }
-      return session;
-    },
-  },
-  providers: [
-    GithubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID ?? "",
-      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? "",
-    }),
-  ],
-  secret: process.env.NEXTAUTH_SECRET,
-};
+import { authOptions } from "@/lib/auth";
 
 const handler = NextAuth(authOptions);
 

--- a/src/app/components/layout/header/header.tsx
+++ b/src/app/components/layout/header/header.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { getServerSession } from "next-auth/next";
 
-import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { authOptions } from "@/lib/auth";
 
 import CreateArticleBtn from "./create-article-btn";
 import LoginBtn from "./login-btn";

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import { Session, User } from "next-auth";
+import GithubProvider from "next-auth/providers/github";
+
+import prisma from "@/lib/prisma/client";
+
+export const authOptions = {
+  adapter: PrismaAdapter(prisma),
+  callbacks: {
+    async session({ session, user }: { session: Session; user: User }) {
+      if (session?.user) {
+        session.user.id = user.id;
+      }
+      return session;
+    },
+  },
+  providers: [
+    GithubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID ?? "",
+      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? "",
+    }),
+  ],
+  secret: process.env.NEXTAUTH_SECRET,
+};


### PR DESCRIPTION
## 実装内容
authOptionsを`[...nextauth]/route.ts`から切り離した
## 実装経緯
ビルド時に，切り離せという警告が出てビルドできなかったので，切り離した
## 動作確認方法

## 懸念点
