### PR TITLE
galleryページサムネ画像スタイル修正

### DIFF
--- a/src/app/components/gallery/ArticleThumbnail.tsx
+++ b/src/app/components/gallery/ArticleThumbnail.tsx
@@ -9,7 +9,7 @@ export default function ArticleThumbnail({ article }: { article: GalleryArticle 
         <div key={article.nodes[0].id} className="relative">
           <div className="rounded border bg-[#fffefc] p-2">
             <Image
-              className="h-[200px] w-full object-cover"
+              className="w-full object-contain"
               src={article.nodes[0].ogp["og:image"]}
               width={153}
               height={78}


### PR DESCRIPTION
## 実装内容
galleryページのサムネ画像表示部のスタイルを修正しました。

## 実装経緯
画面幅を変えた時に、記事サムネが見切れる・外枠のサイズが合っていないといった問題があったため。

## 動作確認方法
galleryページを開いてブラウザの画面幅を変えて、記事のサムネ画像が見切れたりしていなければ大丈夫です。

## 懸念点
特に無いと思います。