### PR TITLE
galleryページ記事サムネサイズ調整

### DIFF
--- a/src/app/components/gallery/ArticleThumbnail.tsx
+++ b/src/app/components/gallery/ArticleThumbnail.tsx
@@ -9,7 +9,7 @@ export default function ArticleThumbnail({ article }: { article: GalleryArticle 
         <div key={article.nodes[0].id} className="relative">
           <div className="rounded border bg-[#fffefc] p-2">
             <Image
-              className="w-full object-contain"
+              className="h-[200px] w-full object-contain"
               src={article.nodes[0].ogp["og:image"]}
               width={153}
               height={78}


### PR DESCRIPTION
## 実装内容
galleryページで記事サムネ画像の大きさが不揃いになるのを修正しました。

## 実装経緯
サムネ画像の大きさが合っていないと見栄えが悪いため。

## 動作確認方法
galleryページにアクセスして記事サムネの大きさがガタガタになっていなければ大丈夫です。

## 懸念点
特に無いと思います。