### PR TITLE
カテゴリの記事ページでの表示

### DIFF
--- a/src/app/(page)/article/[articleId]/page.tsx
+++ b/src/app/(page)/article/[articleId]/page.tsx
@@ -30,8 +30,7 @@ export default async function Page({ params }: { params: { articleId: string } }
           </time>
           <div className="mb-[15px] mt-[10px] flex items-center justify-between">
             <div className="flex gap-2">
-              <p className="size-fit rounded-full border-2 p-1 px-3">Next.js</p>
-              <p className="size-fit rounded-full border-2 p-1 px-3">React</p>
+              <p className="size-fit rounded-full border-2 p-1 px-3">{article.category.name}</p>
             </div>
             <div className="flex items-center gap-3">
               <Avatar className="mx-auto size-10">

--- a/src/types/gallery-articles.d.ts
+++ b/src/types/gallery-articles.d.ts
@@ -1,37 +1,37 @@
 export type GalleryArticle = {
-  id: number;
-  title: string;
-  author: {
-    id: string;
-    name: string;
-    email: string;
-    emailVerified: string;
-    image: string;
-  };
-  authorId: string;
-  createdAt: string;
-  category: {
     id: number;
-    name: string;
-  };
-  nodes: Node[];
-  updatedAt: string;
+    title: string;
+    author: {
+        id: string;
+        name: string;
+        email: string;
+        emailVerified: string;
+        image: string;
+    };
+    authorId: string;
+    createdAt: string;
+    category: {
+        id: number;
+        name: string;
+    };
+    nodes: Node[];
+    updatedAt: string;
 };
 
 export type Node = {
-  id: number;
-  articleId: number;
-  comment: string;
-  createdAt: string;
-  nodeTitle: string;
-  nodeUrl: string;
-  ogp: {
-    "og:image": string;
-    "og:site_name": string;
-    "og:title": string;
-    "og:type": string;
-    "og:url": string;
-  };
-  order: number;
-  updatedAt: string;
+    id: number;
+    articleId: number;
+    comment: string;
+    createdAt: string;
+    nodeTitle: string;
+    nodeUrl: string;
+    ogp: {
+        "og:image": string;
+        "og:site_name": string;
+        "og:title": string;
+        "og:type": string;  
+        "og:url": string;
+    };
+    order: number;
+    updatedAt: string;
 };

--- a/src/types/gallery-articles.d.ts
+++ b/src/types/gallery-articles.d.ts
@@ -1,33 +1,37 @@
 export type GalleryArticle = {
+  id: number;
+  title: string;
+  author: {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: string;
+    image: string;
+  };
+  authorId: string;
+  createdAt: string;
+  category: {
     id: number;
-    title: string;
-    author: {
-        id: string;
-        name: string;
-        email: string;
-        emailVerified: string;
-        image: string;
-    };
-    authorId: string;
-    createdAt: string;
-    nodes: Node[];
-    updatedAt: string;
+    name: string;
+  };
+  nodes: Node[];
+  updatedAt: string;
 };
 
 export type Node = {
-    id: number;
-    articleId: number;
-    comment: string;
-    createdAt: string;
-    nodeTitle: string;
-    nodeUrl: string;
-    ogp: {
-        "og:image": string;
-        "og:site_name": string;
-        "og:title": string;
-        "og:type": string;  
-        "og:url": string;
-    };
-    order: number;
-    updatedAt: string;
+  id: number;
+  articleId: number;
+  comment: string;
+  createdAt: string;
+  nodeTitle: string;
+  nodeUrl: string;
+  ogp: {
+    "og:image": string;
+    "og:site_name": string;
+    "og:title": string;
+    "og:type": string;
+    "og:url": string;
+  };
+  order: number;
+  updatedAt: string;
 };


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
カテゴリの記事ページでの表示
<img width="786" alt="スクリーンショット 2024-08-31 14 39 57" src="https://github.com/user-attachments/assets/4f69d428-c2da-44f8-9225-47b12b0d08aa">


## 実装経緯

## issue
#53 close 

## 動作確認方法
```
npm run dev
```
で任意の記事ページへ
## 懸念点
なし