### PR TITLE
記事プレビュー機能実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.18.0",
         "@radix-ui/react-avatar": "^1.1.0",
+        "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-popover": "^1.1.1",
         "@radix-ui/react-select": "^2.1.1",
@@ -1207,6 +1208,41 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.18.0",
     "@radix-ui/react-avatar": "^1.1.0",
+    "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-select": "^2.1.1",

--- a/src/app/components/new/createArticleHome.tsx
+++ b/src/app/components/new/createArticleHome.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Check, CircleX, Plus } from "lucide-react";
+import { Check, CircleX, Eye, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ControllerRenderProps, useFieldArray, useForm } from "react-hook-form";
@@ -8,6 +8,15 @@ import { toast } from "react-hot-toast";
 import { z } from "zod";
 
 import Heading from "@/app/components/new/heading";
+import PreviewArticle from "@/app/components/new/preview-article";
+import {
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  PreviewDialog,
+} from "@/app/components/new/preview-dialog";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -225,6 +234,31 @@ export default function CreateArticleHome({ categories }: { categories: Category
               {/*公開*/}
               <div>
                 <Heading title="記事の公開" />
+
+                <PreviewDialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      onClick={() => console.log(form.getValues())}
+                      variant="outline"
+                      className="mb-3 flex w-full items-center gap-3 py-3"
+                    >
+                      <Eye />
+                      プレビュー
+                    </Button>
+                  </DialogTrigger>
+
+                  <DialogContent className="flex h-[90vh] flex-col items-center overflow-y-auto">
+                    <DialogHeader>
+                      <DialogTitle>プレビュー</DialogTitle>
+                    </DialogHeader>
+
+                    <DialogDescription>記事は以下の形式で公開されます</DialogDescription>
+
+                    <PreviewArticle formData={form.getValues()} />
+                  </DialogContent>
+                </PreviewDialog>
+
                 <Button
                   type="submit"
                   disabled={isSubmitting || isPublished}

--- a/src/app/components/new/preview-article.tsx
+++ b/src/app/components/new/preview-article.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { format } from "date-fns";
+import { Timer } from "lucide-react";
+import { useSession } from "next-auth/react";
+
+import PreviewCard from "@/app/components/new/preview-card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { FormData } from "@/types/form-data";
+
+export default function PreviewArticle({ formData }: { formData: FormData }) {
+  const { data: session } = useSession();
+
+  if (!session) return <div>認証が必要です</div>;
+
+  const now = new Date();
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-center px-[10px] py-[20px]">
+        <div className="w-full rounded-md bg-white p-8 md:w-[85%] xl:w-3/4 xl:px-[70px]">
+          <h1 className="mb-3 text-3xl font-bold">{formData.title}</h1>
+          <time className="flex items-center gap-2 text-gray-600">
+            <Timer size={18} />
+            {format(now, "yyyy/MM/dd")}
+          </time>
+          <div className="mb-[15px] mt-[10px] flex items-center justify-between">
+            <div className="flex gap-2">
+              <p className="size-fit rounded-full border-2 p-1 px-3">Next.js</p>
+              <p className="size-fit rounded-full border-2 p-1 px-3">React</p>
+            </div>
+            <div className="flex items-center gap-3">
+              <Avatar className="mx-auto size-10">
+                <AvatarImage src={session.user.image!} className="size-10" />
+                <AvatarFallback>{session.user.name}</AvatarFallback>
+              </Avatar>
+              <h2 className="text-lg font-semibold">{session.user.name}</h2>
+            </div>
+          </div>
+          <div className="relative flex flex-col items-center">
+            {/* Vertical line connecting the cards */}
+            <div className="absolute left-1/2 z-0 h-full w-1 -translate-x-1/2 bg-gray-500"></div>
+            <div className="z-10 w-full space-y-8">
+              {/*後で型作ります*/}
+              {formData.nodes.map((node, index) => (
+                <PreviewCard key={index} node={node} index={index} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/new/preview-card.tsx
+++ b/src/app/components/new/preview-card.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { FormDataNode } from "@/types/form-data";
+
+export default function PreviewCard({ index, node }: { index: number; node: FormDataNode }) {
+  return (
+    <div className="mx-auto rounded-lg border bg-[#fffefc] p-6 shadow-sm">
+      <Link href={node.nodeUrl}>
+        <h3 className="mb-4 text-[23px] font-semibold">
+          {index + 1}.{node.nodeTitle}
+        </h3>
+        <div className="flex flex-col gap-3 md:flex-row md:items-center">
+          <Image
+            src={"/gallery-page/no-image.png"}
+            alt={"og_title"}
+            width={300}
+            height={200}
+            className="mb-[10px] mr-4 w-full md:mb-0 md:w-[35%]"
+          />
+          <p className="w-full text-xl md:w-[65%]">{node.nodeTitle}</p>
+        </div>
+        <p className="mt-4 rounded-md border bg-white p-4 text-gray-700">{node.comment}</p>
+      </Link>
+    </div>
+  );
+}

--- a/src/app/components/new/preview-dialog.tsx
+++ b/src/app/components/new/preview-dialog.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const PreviewDialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ children, className, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-[90vw] translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="size-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+  PreviewDialog,
+};

--- a/src/types/form-data.d.ts
+++ b/src/types/form-data.d.ts
@@ -1,0 +1,11 @@
+export type FormData = {
+    title: string;
+    categoryId: string;
+    nodes: FormDataNode[];
+}
+
+export type FormDataNode = {
+    comment?: string;
+    nodeTitle: string;
+    nodeUrl: string;
+}


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
- 記事投稿画面にプレビュー機能を追加しました

## 実装経緯
- 記事のプレビューが必要だったため

## issue
close #54

## 動作確認方法
- 記事投稿画面→プレビューボタンから以下のようにプレビューが表示されれば大丈夫だと思います
<img width="982" alt="スクリーンショット 2024-08-31 17 26 19" src="https://github.com/user-attachments/assets/db2488d5-6e6e-41e4-9dd4-e5d118485ebf">

<img width="1383" alt="スクリーンショット 2024-08-31 17 21 54" src="https://github.com/user-attachments/assets/4c9bfd21-77f9-41fc-8338-673e1917e9f3">

## 懸念点
特に無いと思います