### PR TITLE
新着path一覧ページのUI更新

### DIFF
--- a/src/app/components/gallery/Article.tsx
+++ b/src/app/components/gallery/Article.tsx
@@ -1,7 +1,8 @@
+import { AvatarFallback } from "@radix-ui/react-avatar";
 import { format } from "date-fns";
 import { Timer } from "lucide-react";
-import Image from "next/image";
 
+import { Avatar, AvatarImage } from "@/components/ui/avatar";
 import { GalleryArticle } from "@/types/gallery-articles";
 
 export default function Article({ article }: { article: GalleryArticle }) {
@@ -12,25 +13,26 @@ export default function Article({ article }: { article: GalleryArticle }) {
   const truncatedTitle = truncateTitle(article.title, 20);
 
   return (
-    <article className="relative rounded-xl bg-white px-4 py-3 shadow-sm">
-      {/*タグ*/}
-      <div className="absolute left-0 top-0 bg-yellow-400 px-3 py-1 text-[13px]">{article.category.name}</div>
+    <article className="relative rounded-xl border-2 border-black bg-white px-4 py-3 shadow-sm duration-300 hover:bg-slate-100">
+      {/* タイトルとカテゴリ */}
+      <div className="h-[150px]">
+        <h2 className="mb-[5px] text-2xl font-bold">{truncatedTitle}</h2>
+        <p className="inline-block rounded-xl bg-green-200 p-[0.5em] text-xs">{article.category.name}</p>
+      </div>
 
-      <Image
-        className="my-[30px] h-[180px] w-full object-contain sm:mb-[10px] sm:mt-0"
-        src={article.nodes[0].ogp["og:image"]}
-        width={153}
-        height={78}
-        alt={article.nodes[0].ogp["og:title"]}
-      />
-
-      {/* 記事タイトル */}
-      <h2 className="mb-[5px] text-lg font-bold">{truncatedTitle}</h2>
-
-      {/*投稿日時*/}
-      <div className="flex items-center justify-end gap-2">
-        <Timer size={13} />
-        <time className="text-[10px]">{format(article.createdAt, "yyyy/MM/dd")}</time>
+      {/* 投稿情報 */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Avatar className="">
+            <AvatarImage src={article.author.image} alt={article.author.name} />
+            <AvatarFallback>{article.author.name[0]}</AvatarFallback>
+          </Avatar>
+          <p>{article.author.name}</p>
+        </div>
+        <div className="flex items-center">
+          <Timer size={13} />
+          <time className="">{format(article.createdAt, "yyyy/MM/dd")}</time>
+        </div>
       </div>
     </article>
   );

--- a/src/app/components/shared/article-section.tsx
+++ b/src/app/components/shared/article-section.tsx
@@ -14,7 +14,7 @@ export default function ArticleSection({
   children: ReactNode;
 }) {
   return (
-    <div className="bg-yellow-200">
+    <div className="bg-green-100">
       <div className="flex justify-center">
         <div className="w-[95%] px-[10px] py-[100px] lg:w-[70%]">
           <div>

--- a/src/app/components/top/more-btn.tsx
+++ b/src/app/components/top/more-btn.tsx
@@ -4,9 +4,9 @@ import Link from "next/link";
 export default function MoreBtn() {
   return (
     <div className="flex justify-center">
-      <Link href={`/gallary`} className="flex items-center gap-3 text-yellow-500">
+      <Link href={`/gallary`} className="group flex items-center gap-3 text-yellow-500">
         記事一覧へ
-        <ArrowRight />
+        <ArrowRight className="transition-transform duration-300 ease-out group-hover:translate-x-1" />
       </Link>
     </div>
   );


### PR DESCRIPTION
## チェック
- [x] 余計な差分は存在しないか？

## 実装内容
新着Path一覧ページのUIを更新しました。
<img width="1297" alt="スクリーンショット 2024-12-13 16 28 38" src="https://github.com/user-attachments/assets/3a46f583-d86e-42c5-b467-377ccbf87859" />


## 実装経緯
既存の記事のOGPをサムネイルとして表示するUIに違和感があったため。

## issue
close 

## 動作確認方法

## 懸念点
